### PR TITLE
Removed the '.' from the run command, as it's no longer needed.

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function dnxRunner(dnxCommand, options) {
   }
 
   if (options.run === true) {
-    commands.push('@powershell -NoProfile -ExecutionPolicy unrestricted -Command "for(;;) { Write-Output \"Starting...\"; dnx --watch . ' + dnxCommand + ' }"');
+    commands.push('@powershell -NoProfile -ExecutionPolicy unrestricted -Command "for(;;) { Write-Output \"Starting...\"; dnx --watch ' + dnxCommand + ' }"');
   }
 
   return shell.task(commands, {


### PR DESCRIPTION
The current build doesn't work with the latest pre-release version of DNX; the current working directory is assumed, unless a -p switch is given. Since the plugin always runs DNX in the working directory context of the cwd, no directory ever needs to be passed.
