### PR TITLE
Created an additional option for running a command once

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,12 +12,17 @@ function dnxRunner(dnxCommand, options) {
   options = _.extend({
     restore: true,
     build: false,
-    run: true,
+    watch: true,
+    run: false,
     cwd: './'
   }, options);
 
   if (!options.restore && !options.build && !options.run) {
     throw new gutil.PluginError(PLUGIN_NAME, 'No action has been specified');
+  }
+
+  if (options.watch && options.run) {
+    throw new gutil.PluginError(PLUGIN_NAME, 'Run and watch cannot both be true');
   }
 
   var commands = [];
@@ -30,8 +35,12 @@ function dnxRunner(dnxCommand, options) {
     commands.push('dnu build');
   }
 
-  if (options.run === true) {
+  if (options.watch === true) {
     commands.push('@powershell -NoProfile -ExecutionPolicy unrestricted -Command "for(;;) { Write-Output \"Starting...\"; dnx --watch ' + dnxCommand + ' }"');
+  }
+
+  if (options.run === true) {
+      commands.push('@powershell -NoProfile -ExecutionPolicy unrestricted -Command "Write-Output \"Starting...\"; dnx ' + dnxCommand + ' "');
   }
 
   return shell.task(commands, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-dnx",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Gulp plugin for ASP.NET vNext",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
I wanted to run my 'test' command in my tests project in order to run xUnit unit tests.  I didn't want to use the watch as this was overkill and unnecessary.  Additionally, I wanted to automate deployment for CI and, with the --watch, my grub task would never complete.  Therefore, I've created a second option called 'watch' which I've set as default to true.  I then set the 'run' option to default to false.

Changes: 
- Added 'watch' option for dnx watch and set it to default
- Repurposed 'run' option for executing dnx commands once
- Added a check to ensure that both options weren't set to 'true'
